### PR TITLE
monospace cell_methods names

### DIFF
--- a/appe.adoc
+++ b/appe.adoc
@@ -18,7 +18,7 @@ Description
 
 
 |{set:cellbgcolor!}
-point
+`point`
 |{set:cellbgcolor!}
 __u__
 |{set:cellbgcolor!}
@@ -26,7 +26,7 @@ The data values are representative of points in space or time (instantaneous). T
 
 
 |{set:cellbgcolor!}
-sum
+`sum`
 |{set:cellbgcolor!}
 __u__
 |{set:cellbgcolor!}
@@ -34,7 +34,7 @@ The data values are representative of a sum or accumulation over the cell. This 
 
 
 |{set:cellbgcolor!}
-maximum
+`maximum`
 |{set:cellbgcolor!}
 __u__
 |{set:cellbgcolor!}
@@ -42,7 +42,7 @@ Maximum
 
 
 |{set:cellbgcolor!}
-median
+`median`
 |{set:cellbgcolor!}
 __u__
 |{set:cellbgcolor!}
@@ -50,7 +50,7 @@ Median
 
 
 |{set:cellbgcolor!}
-mid_range
+`mid_range`
 |{set:cellbgcolor!}
 __u__
 |{set:cellbgcolor!}
@@ -58,7 +58,7 @@ Average of maximum and minimum
 
 
 |{set:cellbgcolor!}
-minimum
+`minimum`
 |{set:cellbgcolor!}
 __u__
 |{set:cellbgcolor!}
@@ -66,7 +66,7 @@ Minimum
 
 
 |{set:cellbgcolor!}
-mean
+`mean`
 |{set:cellbgcolor!}
 __u__
 |{set:cellbgcolor!}
@@ -74,7 +74,7 @@ Mean (average value)
 
 
 |{set:cellbgcolor!}
-mode
+`mode`
 |{set:cellbgcolor!}
 __u__
 |{set:cellbgcolor!}
@@ -82,7 +82,7 @@ Mode (most common value)
 
 
 |{set:cellbgcolor!}
-standard_deviation
+`standard_deviation`
 |{set:cellbgcolor!}
 __u__
 |{set:cellbgcolor!}
@@ -90,7 +90,7 @@ Standard deviation
 
 
 |{set:cellbgcolor!}
-variance
+`variance`
 |{set:cellbgcolor!}
 __u^2^__
 |{set:cellbgcolor!}


### PR DESCRIPTION
i've mono-spaced the cell_methods names, which I think is consistent with the original

for 
https://github.com/cf-metadata/cf-conventions/pull/12
